### PR TITLE
Feat: 사용자 정보조회 (+가입) 기능 추가

### DIFF
--- a/src/main/java/com/dayofliberation/config/SwaggerConfig.java
+++ b/src/main/java/com/dayofliberation/config/SwaggerConfig.java
@@ -25,7 +25,7 @@ public class SwaggerConfig implements WebMvcConfigurer {
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("com.travelsphere"))
+                .apis(RequestHandlerSelectors.basePackage("com.dayofliberation"))
                 .paths(PathSelectors.any())
                 .build()
                 .apiInfo(apiInfo());
@@ -38,8 +38,8 @@ public class SwaggerConfig implements WebMvcConfigurer {
      */
     private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-                .title("TRAVEL-SPHERE REST API")
-                .description("Spring boot를 이용한 여행 도우미 앱 REST API")
+                .title("Day_Of_Liberation REST API")
+                .description("Spring boot를 이용한 대출관리 앱 REST API")
                 .version("0.0.1")
                 .contact(new Contact("조현수",
                         "https://github.com/HyunsooZo",

--- a/src/main/java/com/dayofliberation/controller/UserController.java
+++ b/src/main/java/com/dayofliberation/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.dayofliberation.controller;
+
+import com.dayofliberation.dto.UserDto;
+import com.dayofliberation.dto.UserInfoResponseDto;
+import com.dayofliberation.dto.UserUUIDDto;
+import com.dayofliberation.service.UserService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Api(tags = "User API", description = "사용자 관련 API")
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 사용자 정보 조회
+     *
+     * @param userUUIDDto 사용자 UUID DTO
+     * @return ResponseEntity<Void>
+     */
+    @PostMapping
+    @ApiOperation(value = "사용자 ID 조회 (or 가입)", notes = "사용자 정보 조회")
+    public ResponseEntity<UserInfoResponseDto> getUserId(
+            @Valid @RequestBody UserUUIDDto userUUIDDto) {
+
+        UserDto userDto = userService.getUserInfo(userUUIDDto);
+
+        return ResponseEntity.status(OK).body(UserInfoResponseDto.from(userDto));
+    }
+}

--- a/src/main/java/com/dayofliberation/domain/BaseEntity.java
+++ b/src/main/java/com/dayofliberation/domain/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.dayofliberation.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(value = {AuditingEntityListener.class})
+@NoArgsConstructor
+@MappedSuperclass
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dayofliberation/domain/User.java
+++ b/src/main/java/com/dayofliberation/domain/User.java
@@ -1,0 +1,28 @@
+package com.dayofliberation.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class User extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String UUID;
+
+    public static User from(String uuid) {
+        return User.builder()
+                .UUID(uuid)
+                .build();
+    }
+}

--- a/src/main/java/com/dayofliberation/dto/UserDto.java
+++ b/src/main/java/com/dayofliberation/dto/UserDto.java
@@ -1,0 +1,19 @@
+package com.dayofliberation.dto;
+
+import com.dayofliberation.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDto {
+    private String uuid;
+    private Long id;
+
+    public static UserDto from(User user){
+        return UserDto.builder()
+                .uuid(user.getUUID())
+                .id(user.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/dayofliberation/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/dayofliberation/dto/UserInfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.dayofliberation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserInfoResponseDto {
+    private Long id;
+
+    public static UserInfoResponseDto from(UserDto userDto) {
+        return UserInfoResponseDto.builder()
+                .id(userDto.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/dayofliberation/dto/UserUUIDDto.java
+++ b/src/main/java/com/dayofliberation/dto/UserUUIDDto.java
@@ -1,0 +1,17 @@
+package com.dayofliberation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserUUIDDto {
+    @NotBlank(message = "uuid는 필수 입력 값입니다.")
+    private String userUUID;
+}

--- a/src/main/java/com/dayofliberation/repository/UserRepository.java
+++ b/src/main/java/com/dayofliberation/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.dayofliberation.repository;
+
+import com.dayofliberation.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByUUID(String uuid);
+}

--- a/src/main/java/com/dayofliberation/service/UserService.java
+++ b/src/main/java/com/dayofliberation/service/UserService.java
@@ -1,0 +1,34 @@
+package com.dayofliberation.service;
+
+import com.dayofliberation.domain.User;
+import com.dayofliberation.dto.UserDto;
+import com.dayofliberation.dto.UserUUIDDto;
+import com.dayofliberation.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 정보 조회 (없을 경우 회원가입 후 아이디 반환)
+     *
+     * @param userUUIDDto 사용자 UUID DTO
+     * @return UserDto
+     */
+    public UserDto getUserInfo(UserUUIDDto userUUIDDto) {
+
+        User user = userRepository.findByUUID(userUUIDDto.getUserUUID())
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .UUID(userUUIDDto.getUserUUID())
+                            .build();
+
+                    return userRepository.save(newUser);
+                });
+
+        return UserDto.from(user);
+    }
+}

--- a/src/test/java/com/dayofliberation/service/UserInfoServiceTest.java
+++ b/src/test/java/com/dayofliberation/service/UserInfoServiceTest.java
@@ -1,0 +1,75 @@
+package com.dayofliberation.service;
+
+import com.dayofliberation.domain.User;
+import com.dayofliberation.dto.UserDto;
+import com.dayofliberation.dto.UserUUIDDto;
+import com.dayofliberation.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@DisplayName("사용자 정보 조회/가입 테스트")
+class UserInfoServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("사용자 존재 -> 사용자 정보 조회")
+    public void testGetUserInfo_UserExists() {
+        // Given
+        String userUUID = "existingUUID";
+        UserUUIDDto userUUIDDto = new UserUUIDDto(userUUID);
+        User existingUser = User.builder()
+                .UUID(userUUID)
+                .build();
+
+        when(userRepository.findByUUID(userUUID)).thenReturn(Optional.of(existingUser));
+
+        // When
+        UserDto result = userService.getUserInfo(userUUIDDto);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUuid()).isEqualTo(userUUID);
+    }
+
+    @Test
+    @DisplayName("사용자 없음 -> 사용자 가입")
+    public void testGetUserInfo_UserDoesNotExist() {
+        // Given
+        String userUUID = "nonExistingUUID";
+        UserUUIDDto userUUIDDto = new UserUUIDDto(userUUID);
+
+        when(userRepository.findByUUID(userUUID)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            return User.builder()
+                    .id(1L)
+                    .UUID(userUUID)
+                    .build();
+        });
+
+        // When
+        UserDto result = userService.getUserInfo(userUUIDDto);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUuid()).isEqualTo(userUUID);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 사용자 정보조회 (+가입) 기능 추가
### 변경 사항(추가 시엔 추가 사항)
- id/pw입력방식이 아닌, 단순 UUID 인증 방식으로 구현
- 화면 진입 시 쿠키에서 uuid 저장여부 확인, 저장되어있지 않을 시 
새로 생성하여 저장하고 해당 uuid 기반 데이터 조회하여 노출예정
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음