### PR TITLE
Feat: 사용자가 등록한 대출 목록 조회기능 추가

### DIFF
--- a/src/main/java/com/dayofliberation/controller/LoanController.java
+++ b/src/main/java/com/dayofliberation/controller/LoanController.java
@@ -1,19 +1,21 @@
 package com.dayofliberation.controller;
 
 import com.dayofliberation.dto.LoanCreationRequestDto;
+import com.dayofliberation.dto.LoanDto;
+import com.dayofliberation.dto.LoanListResponseDto;
 import com.dayofliberation.service.LoanService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @Api(tags = "Loan API", description = "대출 관련 API")
 @RequestMapping("/api/v1/loans")
@@ -37,5 +39,20 @@ public class LoanController {
         loanService.createLoan(loanCreationRequestDto);
 
         return ResponseEntity.status(CREATED).build();
+    }
+
+    /**
+     * 대출 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return ResponseEntity<List<LoanDto>>
+     */
+    @GetMapping
+    @ApiOperation(value = "대출 목록 조회", notes = "대출 목록 조회")
+    public ResponseEntity<LoanListResponseDto> getLoan(@RequestParam Long userId) {
+
+        List<LoanDto> loans = loanService.getLoans(userId);
+
+        return ResponseEntity.status(OK).body(LoanListResponseDto.from(loans));
     }
 }

--- a/src/main/java/com/dayofliberation/domain/Bank.java
+++ b/src/main/java/com/dayofliberation/domain/Bank.java
@@ -14,7 +14,7 @@ import javax.persistence.Id;
 @NoArgsConstructor
 @Builder
 @Entity
-public class Bank extends BaseEntity {
+public class Bank {
 
     @Id
     private Long id;

--- a/src/main/java/com/dayofliberation/domain/Loan.java
+++ b/src/main/java/com/dayofliberation/domain/Loan.java
@@ -20,7 +20,7 @@ public class Loan extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     private Bank bank;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dayofliberation/dto/LoanDto.java
+++ b/src/main/java/com/dayofliberation/dto/LoanDto.java
@@ -1,0 +1,54 @@
+package com.dayofliberation.dto;
+
+import com.dayofliberation.domain.Bank;
+import com.dayofliberation.domain.Loan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoanDto {
+    private Long id;
+    private Bank bank;
+    private Long userId;
+    private String name; // 대출 이름
+    private String purpose; // 대출 목적
+    private String repaymentMethod; // 상환 방식
+    private Date executionDate; // 대출 실행일
+    private Integer repaymentPeriod; // 상환 기간 (개월)
+    private Date expirationDate; // 만기일
+    private Integer gracePeriod; // 유예 기간 (개월)
+    private Double interestRate; // 이자율
+    private BigDecimal totalAmount; // 총 대출 금액
+    private BigDecimal repaymentAmount; // 상환 금액
+    private LocalDateTime createdAt; // 생성일
+    private LocalDateTime updatedAt; // 수정일
+
+    public static LoanDto from(Loan loan) {
+        return LoanDto.builder()
+                .id(loan.getId())
+                .bank(loan.getBank())
+                .userId(loan.getUser().getId())
+                .name(loan.getName())
+                .purpose(loan.getPurpose())
+                .repaymentMethod(loan.getRepaymentMethod())
+                .executionDate(loan.getExecutionDate())
+                .repaymentPeriod(loan.getRepaymentPeriod())
+                .expirationDate(loan.getExpirationDate())
+                .gracePeriod(loan.getGracePeriod())
+                .interestRate(loan.getInterestRate())
+                .totalAmount(loan.getTotalAmount())
+                .repaymentAmount(loan.getRepaymentAmount())
+                .createdAt(loan.getCreatedAt())
+                .updatedAt(loan.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dayofliberation/dto/LoanListResponseDto.java
+++ b/src/main/java/com/dayofliberation/dto/LoanListResponseDto.java
@@ -1,0 +1,22 @@
+package com.dayofliberation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoanListResponseDto {
+    private List<LoanDto> loans;
+
+    public static LoanListResponseDto from(List<LoanDto> loans) {
+        return LoanListResponseDto.builder()
+                .loans(loans)
+                .build();
+    }
+}

--- a/src/main/java/com/dayofliberation/exception/ErrorCode.java
+++ b/src/main/java/com/dayofliberation/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     USER_STATUS_NOT_ACTIVE(BAD_REQUEST, "사용자 상태가 활성화되어 있지 않습니다."),
 
     //bank
-    BANK_NOT_FOUND(NOT_FOUND, "존재하지 않는 은행입니다.");
+    BANK_NOT_FOUND(NOT_FOUND, "존재하지 않는 은행입니다."),
+
+    //loan
+    LOAN_NOT_FOUND(NOT_FOUND,"존재하지 않는 대출입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/dayofliberation/repository/LoanRepository.java
+++ b/src/main/java/com/dayofliberation/repository/LoanRepository.java
@@ -1,8 +1,12 @@
 package com.dayofliberation.repository;
 
 import com.dayofliberation.domain.Loan;
+import com.dayofliberation.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface LoanRepository extends JpaRepository<Loan, Long> {
 
+    List<Loan> findByUser(User user);
 }

--- a/src/main/java/com/dayofliberation/service/LoanService.java
+++ b/src/main/java/com/dayofliberation/service/LoanService.java
@@ -4,6 +4,7 @@ import com.dayofliberation.domain.Bank;
 import com.dayofliberation.domain.Loan;
 import com.dayofliberation.domain.User;
 import com.dayofliberation.dto.LoanCreationRequestDto;
+import com.dayofliberation.dto.LoanDto;
 import com.dayofliberation.exception.CustomException;
 import com.dayofliberation.exception.ErrorCode;
 import com.dayofliberation.repository.BankRepository;
@@ -12,6 +13,9 @@ import com.dayofliberation.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -35,5 +39,23 @@ public class LoanService {
         Loan loan = Loan.from(bank, user, loanCreationRequestDto);
 
         loanRepository.save(loan);
+    }
+
+    /**
+     * 대출 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return Loan
+     */
+    @Transactional(readOnly = true)
+    public List<LoanDto> getLoans(Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_INFO_NOT_FOUND)
+        );
+
+        return loanRepository.findByUser(user).stream()
+                .map(LoanDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/dayofliberation/service/LoanInquiryServiceTest.java
+++ b/src/test/java/com/dayofliberation/service/LoanInquiryServiceTest.java
@@ -1,0 +1,73 @@
+package com.dayofliberation.service;
+
+import com.dayofliberation.domain.Bank;
+import com.dayofliberation.domain.Loan;
+import com.dayofliberation.domain.User;
+import com.dayofliberation.dto.LoanDto;
+import com.dayofliberation.repository.BankRepository;
+import com.dayofliberation.repository.LoanRepository;
+import com.dayofliberation.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@DisplayName("대출 조회 테스트")
+class LoanInquiryServiceTest {
+
+    @Mock
+    private LoanRepository loanRepository;
+    @Mock
+    private BankRepository bankRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private LoanService loanService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        loanService = new LoanService(loanRepository, bankRepository, userRepository);
+    }
+
+    @Test
+    @DisplayName("성공")
+    void inquireLoan() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .UUID("test")
+                .build();
+
+        Loan loan = Loan.builder()
+                .bank(new Bank(1L, "국민은행"))
+                .gracePeriod(0)
+                .interestRate(0.02)
+                .repaymentMethod("원리금균등")
+                .repaymentPeriod(12)
+                .executionDate(java.sql.Date.valueOf("2021-01-01"))
+                .name("대출")
+                .purpose("대출 목적")
+                .totalAmount(java.math.BigDecimal.valueOf(1000000))
+                .user(user)
+                .repaymentAmount(java.math.BigDecimal.valueOf(100000))
+                .expirationDate(java.sql.Date.valueOf("2022-01-01"))
+                .build();
+
+        Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        Mockito.when(loanRepository.findByUser(user)).thenReturn(Collections.singletonList(loan));
+
+        // when
+        List<LoanDto> loans = loanService.getLoans(1L);
+
+        // then
+        Assertions.assertThat(loans.get(0).getId()).isEqualTo(loan.getId());
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 사용자가 등록한 대출목록 조회기능 추가
### 변경 사항(추가 시엔 추가 사항)
- 사용자가 등록한 대출 모든 목록을 조회하여 반환
- `Bank` 엔티티 내부의 불필요한 필드 삭제
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음